### PR TITLE
Added more options for selescrape

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -21,6 +21,8 @@ DEFAULT_CONFIG = {
         'external_downloader': '',
         'aria2c_for_torrents': False,
         'selescrape_browser': ".",
+        'selescrape_browser_executable_path' : '.',
+        'selescrape_driver_binary_path' : '.',
     },
     'watch': {
         'quality': '1080p',


### PR DESCRIPTION
1. Path to the browser executable
2. Path to the webdriver. (chromedriver/geckodriver)
This update is helpful in case there is a problem with finding the browser or the driver.